### PR TITLE
Fixed #12: Restrict lifecycle-mapping

### DIFF
--- a/eclipse-external-annotations-m2e-plugin.core/lifecycle-mapping-metadata.xml
+++ b/eclipse-external-annotations-m2e-plugin.core/lifecycle-mapping-metadata.xml
@@ -10,6 +10,33 @@
           <goal>compile</goal>
           <goal>test-compile</goal>
         </goals>
+        <parameters>
+          <compilerId>jdt</compilerId>
+        </parameters>
+      </pluginExecutionFilter>
+      <action>
+        <configurator>
+          <id>org.lastnpe.m2e.core.configurator.ClasspathConfigurator</id>
+          <runOnIncremental>false</runOnIncremental>
+          <runOnConfiguration>true</runOnConfiguration>
+        </configurator>
+      </action>
+    </pluginExecution>
+    <!-- We have to copy/paste REPEAT above below now,
+         just for compilerId eclipse instead of jdt;
+         it's otherwise identical, and must be kept in sync -->
+    <pluginExecution>
+      <pluginExecutionFilter>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <versionRange>[2.3,)</versionRange>
+        <goals>
+          <goal>compile</goal>
+          <goal>test-compile</goal>
+        </goals>
+        <parameters>
+          <compilerId>eclipse</compilerId>
+        </parameters>
       </pluginExecutionFilter>
       <action>
         <configurator>
@@ -20,5 +47,4 @@
       </action>
     </pluginExecution>
   </pluginExecutions>
-
 </lifecycleMappingMetadata>


### PR DESCRIPTION
Trigger the ClasspathConfigurator only for "eclipse" or "jdt" compiler.
Otherwise running the extension is just unnecessary overhead.

Similar to
https://github.com/jbosstools/m2e-jdt-compiler/blob/master/org.jboss.tools.m2e.jdt.core/lifecycle-mapping-metadata.xml