### PR TITLE
support maven properties for different classpath entries and paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,13 +7,27 @@ Configures the path to Eclipse external annotations for null analysis on the Mav
 
 1. Allows to configure Java Compiler Project Properties from maven-compiler-plugin; read either from a dependency of maven-compiler-plugin containing a org.eclipse.jdt.core.prefs file, or from configuration/compilerArguments/properties.
 
-2. Allows to configure the path to external annotations for the Maven Dependencies and JRE classpath containers.  The path is
-  - either taken from the &quot;m2e.jdt.annotationpath&quot; property in POM files, if it exists (this for configuring one single archive of *.eea for ALL Maven dependencies AND the JRE), 
-  - or by individually associating archives on the projects main (not maven-compiler-plugin) dependencies with classpath entries, based on a eea-for-gav marker file in the *-eea.jar which indicates for which Maven GAV it holds external annotations.
+2. Allows to configure the path to external annotations for the Maven Dependencies and JRE classpath containers.
+   The path is
+
+   * either taken from the `m2e.jdt.annotationpath` property in POM files, if it exists.
+     This is used to configure one single archive of *.eea for ALL Maven dependencies AND the JRE.
+
+   * or taken from the different properties in POM files. This is used to configure different locations for JRE and Maven dependencies.
+     * `m2e.eea.annotationpath.jre`: The annotation path for JRE
+     * `m2e.eea.annotationpath.maven`: The annotation path for Maven dependencies
+     * `m2e.eea.annotationpath.pde`: The annotation path for required PDE plugins
+
+   * or by individually associating archives on the projects main (not maven-compiler-plugin) dependencies with classpath entries, based on a eea-for-gav marker file in the *-eea.jar which indicates for which Maven GAV it holds external annotations.
 
 p2 update site to install this from: `http://www.lastnpe.org/eclipse-external-annotations-m2e-plugin-p2-site/` _(The 404 is normal, just because there is no index.html; it will work in Eclipse.)_
 
-You can also build it yourself: `git clone https://github.com/lastnpe/eclipse-external-annotations-m2e-plugin.git; ./mvnw clean package`
+You can also build it yourself:
+
+```
+git clone https://github.com/lastnpe/eclipse-external-annotations-m2e-plugin.git
+./mvnw clean package
+```
 
 see usage examples in [lastnpe/eclipse-null-eea-augments/examples/](https://github.com/lastnpe/eclipse-null-eea-augments/tree/master/examples/maven) (or [sylvainlaurent/null-pointer-analysis-examples](https://github.com/sylvainlaurent/null-pointer-analysis-examples/tree/master/with-external-annotations) for the older single EEA approach).
 


### PR DESCRIPTION
The changes are split into two commits.

The first commit only changes some coding format. Mainly it adds `final` keyword where possible. If you agree that it doesn't make anything more bad, it would be great if we could use it.

The second commit contains the real code changes.

If you review the changes you should perhaps look at the second commit only.

Fixes: https://github.com/lastnpe/eclipse-external-annotations-m2e-plugin/issues/24