### PR TITLE
relax dependency on m2e plugins to be compatible with Eclipse 4.8 Photon

### DIFF
--- a/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
+++ b/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
@@ -6,9 +6,9 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: lastnpe.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.6.0,1.9.0)",
- org.eclipse.m2e.core;bundle-version="[1.6.0,1.9.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.6.0,1.9.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.6.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.6.0,2.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.6.0,2.0.0)",
  org.slf4j.api,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core


### PR DESCRIPTION
fix for https://github.com/lastnpe/eclipse-external-annotations-m2e-plugin/issues/28