### PR TITLE
remove M2E <= 1.8.x contraint from MANIFEST.MF

### DIFF
--- a/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
+++ b/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
@@ -6,9 +6,9 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: lastnpe.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.6.0,1.9.0)",
- org.eclipse.m2e.core;bundle-version="[1.6.0,1.9.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.6.0,1.9.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[1.6.0,2.0.0)",
+ org.eclipse.m2e.core;bundle-version="[1.6.0,2.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[1.6.0,2.0.0)",
  org.slf4j.api,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core


### PR DESCRIPTION
the current constraint makes testing it e.g. on Photon with
upcoming M2E 1.9.0 from http://download.eclipse.org/technology/m2e/milestones/1.9/
difficult.. IMHO there is no real good reason to enforce this as it is currently,
and it would be perfectly OK to permit any 1.x m2e version...

see also e.g. https://github.com/m2e-code-quality/m2e-code-quality/issues/114