### PR TITLE
Simplified fix for issue #37

### DIFF
--- a/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
+++ b/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
@@ -11,6 +11,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.jdt;bundle-version="[1.6.0,2.0.0)",
  org.slf4j.api,
  org.eclipse.jdt.launching,
- org.eclipse.debug.core
+ org.eclipse.debug.core,
+ org.apache.commons.io
 Bundle-RequiredExecutionEnvironment: JavaSE-1.8
 Bundle-ActivationPolicy: lazy


### PR DESCRIPTION
Makes use of the old java.util.zip.ZipFile API instead of
java.nio.file.FileSystems for looking inside of Jar files.