### PR TITLE
Fixes breaking changes from m2e 2.0.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: java
 
 jdk:
-  - openjdk8
+  - openjdk17
 
 script: ./mvnw clean verify
 

--- a/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
+++ b/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
@@ -6,12 +6,12 @@ Bundle-Version: 1.0.0.qualifier
 Bundle-Vendor: lastnpe.org
 Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.jdt.core,
- org.eclipse.m2e.maven.runtime;bundle-version="[1.6.0,2.0.0)",
- org.eclipse.m2e.core;bundle-version="[1.6.0,3.0.0)",
- org.eclipse.m2e.jdt;bundle-version="[1.6.0,2.0.0)",
+ org.eclipse.m2e.maven.runtime;bundle-version="[3.8.0,4.0.0)",
+ org.eclipse.m2e.core;bundle-version="[2.0.1,3.0.0)",
+ org.eclipse.m2e.jdt;bundle-version="[2.0.1,3.0.0)",
  org.slf4j.api,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
  org.apache.commons.io
-Bundle-RequiredExecutionEnvironment: JavaSE-1.8
+Bundle-RequiredExecutionEnvironment: JavaSE-17
 Bundle-ActivationPolicy: lazy

--- a/eclipse-external-annotations-m2e-plugin.core/src/org/lastnpe/m2e/core/configurator/ClasspathConfigurator.java
+++ b/eclipse-external-annotations-m2e-plugin.core/src/org/lastnpe/m2e/core/configurator/ClasspathConfigurator.java
@@ -210,7 +210,7 @@ public class ClasspathConfigurator extends AbstractProjectConfigurator implement
     @Override
     public void configureRawClasspath(final ProjectConfigurationRequest request, final IClasspathDescriptor classpath,
             final IProgressMonitor monitor) throws CoreException {
-        final IMavenProjectFacade mavenProjectFacade = request.getMavenProjectFacade();
+        final IMavenProjectFacade mavenProjectFacade = request.mavenProjectFacade();
 
         /*
          * First check for the property for one global path for all classpaths.
@@ -247,7 +247,7 @@ public class ClasspathConfigurator extends AbstractProjectConfigurator implement
 
         final Optional<String> cpe = Optional.of(JRE_CONTAINER);
 
-        final MavenProject mavenProject = request.getMavenProject();
+        final MavenProject mavenProject = request.mavenProject();
         for (final Dependency dependency : mavenProject.getDependencies()) {
             // Filter by "*-eea" artifactId naming convention, just for performance
             if (!dependency.getArtifactId().endsWith("-eea")) {
@@ -369,7 +369,7 @@ public class ClasspathConfigurator extends AbstractProjectConfigurator implement
     @Override
     public void configure(final ProjectConfigurationRequest projectConfigurationRequest, final IProgressMonitor monitor)
             throws CoreException {
-        final MavenProject mavenProject = projectConfigurationRequest.getMavenProject();
+        final MavenProject mavenProject = projectConfigurationRequest.mavenProject();
         final Plugin plugin = mavenProject.getPlugin("org.apache.maven.plugins:maven-compiler-plugin");
         if (plugin == null) {
             return;
@@ -389,7 +389,7 @@ public class ClasspathConfigurator extends AbstractProjectConfigurator implement
                     final Properties configurationCompilerArgumentsProperties = new Properties();
                     try {
                         configurationCompilerArgumentsProperties.load(new StringReader(propertiesAsText));
-                        configureProjectFromProperties(projectConfigurationRequest.getProject(),
+                        configureProjectFromProperties(projectConfigurationRequest.mavenProjectFacade().getProject(),
                                 configurationCompilerArgumentsProperties);
                         return;
                     } catch (final IOException e) {
@@ -433,7 +433,7 @@ public class ClasspathConfigurator extends AbstractProjectConfigurator implement
         try (FileInputStream inputStream = new FileInputStream(configurationCompilerArgumentsFile)) {
             final Properties configurationCompilerArgumentsProperties = new Properties();
             configurationCompilerArgumentsProperties.load(inputStream);
-            configureProjectFromProperties(projectConfigurationRequest.getProject(),
+            configureProjectFromProperties(projectConfigurationRequest.mavenProjectFacade().getProject(),
                     configurationCompilerArgumentsProperties);
             return;
         } catch (final IOException e) {

--- a/eclipse-external-annotations-m2e-plugin.core/src/org/lastnpe/m2e/core/configurator/MavenGAV.java
+++ b/eclipse-external-annotations-m2e-plugin.core/src/org/lastnpe/m2e/core/configurator/MavenGAV.java
@@ -55,10 +55,10 @@ public class MavenGAV {
     }
 
     public boolean matches(ArtifactKey artifactKey) {
-        return groupId.equals(artifactKey.getGroupId())
-            && artifactId.equals(artifactKey.getArtifactId())
-            && (!version.isPresent() || version.get().equals(artifactKey.getVersion()))
-            && (!classifier.isPresent() || classifier.get().equals(artifactKey.getClassifier()));
+        return groupId.equals(artifactKey.groupId())
+            && artifactId.equals(artifactKey.artifactId())
+            && (!version.isPresent() || version.get().equals(artifactKey.version()))
+            && (!classifier.isPresent() || classifier.get().equals(artifactKey.classifier()));
     }
 
     @Override

--- a/eclipse-external-annotations-m2e-plugin.feature/pom.xml
+++ b/eclipse-external-annotations-m2e-plugin.feature/pom.xml
@@ -39,10 +39,8 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
-        <version>2.3.2</version>
+        <version>3.10.1</version>
         <configuration>
-          <source>1.6</source>
-          <target>1.6</target>
           <encoding>UTF-8</encoding>
         </configuration>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -15,14 +15,17 @@
 
   <repositories>
     <repository>
-      <id>neon</id>
+      <id>2022-09</id>
       <layout>p2</layout>
-      <url>http://download.eclipse.org/releases/neon</url>
+      <url>https://download.eclipse.org/releases/2022-09</url>
     </repository>
   </repositories>
 
   <properties>
-    <tycho-version>0.26.0</tycho-version>
+    <tycho-version>3.0.0</tycho-version>
+    
+	<maven.compiler.source>17</maven.compiler.source>
+	<maven.compiler.target>17</maven.compiler.target>
   </properties>
 
   <modules>


### PR DESCRIPTION
Move to Eclipse 2022-09 and m2e 2.0.1 and maven.runtime 3.8.0
Needs Java 17 (as does m2e 2.0.1)
see [m2e-core RELEASE_NOTES](https://github.com/eclipse-m2e/m2e-core/blob/master/RELEASE_NOTES.md#201)