### PR TITLE
Update POMs to 2.0.0-SNAPSHOT and add update site to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build Status](https://travis-ci.org/lastnpe/eclipse-external-annotations-m2e-plugin.svg)](https://travis-ci.org/lastnpe/eclipse-external-annotations-m2e-plugin)
-
 Eclipse Maven integration (M2E extension) for null analysis
 ----
 
@@ -20,7 +18,14 @@ Configures the path to Eclipse external annotations for null analysis on the Mav
 
    * or by individually associating archives on the projects main (not maven-compiler-plugin) dependencies with classpath entries, based on a eea-for-gav marker file in the *-eea.jar which indicates for which Maven GAV it holds external annotations.
 
-p2 update site to install this from: `http://www.lastnpe.org/eclipse-external-annotations-m2e-plugin-p2-site/` _(The 404 is normal, just because there is no index.html; it will work in Eclipse.)_
+p2 update sites to install this from:
+
+* Recent Eclipse versions (>= 2022-09)  
+  https://www.lastnpe.org/eclipse-external-annotations-m2e-plugin-p2-site/m2e_2/
+* Older Eclipse versions (<= 2022-06)  
+  https://www.lastnpe.org/eclipse-external-annotations-m2e-plugin-p2-site/
+
+_These URLs will work with Eclipse but return a 404 error in browsers because they do not have an index.html file._
 
 You can also build it yourself:
 
@@ -29,8 +34,8 @@ git clone https://github.com/lastnpe/eclipse-external-annotations-m2e-plugin.git
 ./mvnw clean package
 ```
 
-see usage examples in [lastnpe/eclipse-null-eea-augments/examples/](https://github.com/lastnpe/eclipse-null-eea-augments/tree/master/examples/maven) (or [sylvainlaurent/null-pointer-analysis-examples](https://github.com/sylvainlaurent/null-pointer-analysis-examples/tree/master/with-external-annotations) for the older single EEA approach).
+See usage examples in [lastnpe/eclipse-null-eea-augments/examples/](https://github.com/lastnpe/eclipse-null-eea-augments/tree/master/examples/maven) (or [sylvainlaurent/null-pointer-analysis-examples](https://github.com/sylvainlaurent/null-pointer-analysis-examples/tree/master/with-external-annotations) for the older single EEA approach).
 
 If you like/use this project, a Star / Watch / Follow on GitHub is appreciated.
 
-see also http://lastnpe.org
+See also https://www.lastnpe.org/

--- a/eclipse-external-annotations-m2e-plugin.core/pom.xml
+++ b/eclipse-external-annotations-m2e-plugin.core/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.lastnpe.m2e</groupId>
 		<artifactId>eclipse-external-annotations-m2e-plugin</artifactId>
-		<version>1.0.0-SNAPSHOT</version>
+		<version>2.0.0-SNAPSHOT</version>
 	</parent>
 
 	<artifactId>org.lastnpe.m2e.core</artifactId>

--- a/eclipse-external-annotations-m2e-plugin.feature/pom.xml
+++ b/eclipse-external-annotations-m2e-plugin.feature/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.lastnpe.m2e</groupId>
     <artifactId>eclipse-external-annotations-m2e-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
   <artifactId>org.lastnpe.m2e.feature</artifactId>

--- a/eclipse-external-annotations-m2e-plugin.site/pom.xml
+++ b/eclipse-external-annotations-m2e-plugin.site/pom.xml
@@ -6,7 +6,7 @@
   <parent>
     <groupId>org.lastnpe.m2e</groupId>
     <artifactId>eclipse-external-annotations-m2e-plugin</artifactId>
-    <version>1.0.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
   </parent>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
   <groupId>org.lastnpe.m2e</groupId>
   <artifactId>eclipse-external-annotations-m2e-plugin</artifactId>
 
-  <version>1.0.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Also switches some URLs to HTTPS and removes the Travis CI badge.

See: https://github.com/lastnpe/eclipse-external-annotations-m2e-plugin/issues/47#issuecomment-1345391352