### PR TITLE
Revert "Specify slf4j version to fix install error"

### DIFF
--- a/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
+++ b/eclipse-external-annotations-m2e-plugin.core/META-INF/MANIFEST.MF
@@ -9,7 +9,7 @@ Require-Bundle: org.eclipse.core.runtime,
  org.eclipse.m2e.maven.runtime;bundle-version="[3.8.0,4.0.0)",
  org.eclipse.m2e.core;bundle-version="[2.0.1,3.0.0)",
  org.eclipse.m2e.jdt;bundle-version="[2.0.1,3.0.0)",
- org.slf4j.api;bundle-version="[2.0.1,3.0.0)",
+ org.slf4j.api,
  org.eclipse.jdt.launching,
  org.eclipse.debug.core,
  org.apache.commons.io


### PR DESCRIPTION
Reverts lastnpe/eclipse-external-annotations-m2e-plugin#54,

due to the problem shown on #55.

@Monniasza FYI